### PR TITLE
Implement GTFS data download and display hook

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,17 +1,38 @@
-import React from 'react';
-
+import React, {useEffect} from 'react';
+import {ActivityIndicator, View, Text} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 
-import HomeScreen from 'HomeScreen';
-import RoutesScreen from 'RoutesScreen';
-import RouteScreen from 'RouteScreen';
-import StopsScreen from 'StopsScreen';
-import StopScreen from 'StopScreen';
+import HomeScreen from './src/HomeScreen';
+import RoutesScreen from './src/RoutesScreen';
+import RouteScreen from './src/RouteScreen';
+import StopsScreen from './src/StopsScreen';
+import StopScreen from './src/StopScreen';
+import useGTFSData from './src/hooks/useGTFSData'; // Import the hook
 
 const Stack = createNativeStackNavigator();
 
 function App(): JSX.Element {
+  const { data, loading, error } = useGTFSData();
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" />
+        <Text>Loading GTFS data...</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>Error loading GTFS data:</Text>
+        <Text>{error.message}</Text>
+      </View>
+    );
+  }
+
   return (
     <NavigationContainer>
       <Stack.Navigator>
@@ -20,10 +41,15 @@ function App(): JSX.Element {
           component={HomeScreen}
           options={{title: 'Welcome'}}
         />
-        <Stack.Screen name="Routes" component={RoutesScreen} />
+        <Stack.Screen name="Routes">
+          {(props) => <RoutesScreen {...props} routes={data.routes} />}
+        </Stack.Screen>
         <Stack.Screen name="Route" component={RouteScreen} />
-        <Stack.Screen name="Stops" component={StopsScreen} />
+        <Stack.Screen name="Stops">
+          {(props) => <StopsScreen {...props} stops={data.stops} />}
+        </Stack.Screen>
         <Stack.Screen name="Stop" component={StopScreen} />
+        {/* We'll add TripsScreen later if needed */}
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/App.tsx
+++ b/App.tsx
@@ -3,12 +3,12 @@ import {ActivityIndicator, View, Text} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 
-import HomeScreen from './src/HomeScreen';
-import RoutesScreen from './src/RoutesScreen';
-import RouteScreen from './src/RouteScreen';
-import StopsScreen from './src/StopsScreen';
-import StopScreen from './src/StopScreen';
-import useGTFSData from './src/hooks/useGTFSData'; // Import the hook
+import HomeScreen from 'HomeScreen';
+import RoutesScreen from 'RoutesScreen';
+import RouteScreen from 'RouteScreen';
+import StopsScreen from 'StopsScreen';
+import StopScreen from 'StopScreen';
+import useGTFSData from './src/hooks/useGTFSData';
 
 const Stack = createNativeStackNavigator();
 
@@ -49,7 +49,6 @@ function App(): JSX.Element {
           {(props) => <StopsScreen {...props} stops={data.stops} />}
         </Stack.Screen>
         <Stack.Screen name="Stop" component={StopScreen} />
-        {/* We'll add TripsScreen later if needed */}
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,13 @@
       "dependencies": {
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/native-stack": "^6.9.17",
+        "papaparse": "^5.5.3",
         "react": "18.2.0",
         "react-native": "0.72.4",
         "react-native-safe-area-context": "^4.8.2",
-        "react-native-screens": "^3.29.0"
+        "react-native-screens": "^3.29.0",
+        "react-native-zip-archive": "^7.0.2",
+        "rn-fetch-blob": "^0.12.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -5701,6 +5704,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -11891,6 +11899,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12372,6 +12386,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-zip-archive": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-zip-archive/-/react-native-zip-archive-7.0.2.tgz",
+      "integrity": "sha512-msCRJMcwH6NVZ2/zoC+1nvA0wlpYRnMxteQywS9nt4BzXn48tZpaVtE519QEZn0xe3ygvgsWx5cdPoE9Jx3bsg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.6",
+        "react-native": ">=0.60.0"
+      }
+    },
     "node_modules/react-native/node_modules/@jest/types": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
@@ -12766,6 +12790,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rn-fetch-blob": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/rn-fetch-blob/-/rn-fetch-blob-0.12.0.tgz",
+      "integrity": "sha512-+QnR7AsJ14zqpVVUbzbtAjq0iI8c9tCg49tIoKO2ezjzRunN7YL6zFSFSWZm6d+mE/l9r+OeDM3jmb2tBb2WbA==",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "0.1.0",
+        "glob": "7.0.6"
+      }
+    },
+    "node_modules/rn-fetch-blob/node_modules/glob": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+      "integrity": "sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
   "dependencies": {
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
+    "papaparse": "^5.5.3",
     "react": "18.2.0",
     "react-native": "0.72.4",
     "react-native-safe-area-context": "^4.8.2",
-    "react-native-screens": "^3.29.0"
+    "react-native-screens": "^3.29.0",
+    "react-native-zip-archive": "^7.0.2",
+    "rn-fetch-blob": "^0.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -18,7 +18,9 @@ function HomeScreen({navigation}): JSX.Element {
         return (
           <Section
             title={item.title}
-            onPressHandler={() => { navigation.navigate(`${item.key}`); }}
+            onPressHandler={() =>
+              navigation.navigate(`${item.key}`)
+            }
             isDarkMode={isDarkMode}
           />
         );

--- a/src/RouteScreen.tsx
+++ b/src/RouteScreen.tsx
@@ -20,9 +20,9 @@ function RouteScreen({navigation, route}): JSX.Element {
         return (
           <Section
             title={titleString}
-            onPressHandler={() => {
-              navigation.navigate('Stop', {stopId: `${item.stopId}`});
-            }}
+            onPressHandler={() =>
+              navigation.navigate('Stop', {stopId: `${item.stopId}`})
+            }
             isDarkMode={isDarkMode}
           />
         );

--- a/src/RoutesScreen.tsx
+++ b/src/RoutesScreen.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {useColorScheme, Text, View} from 'react-native';
 
-import Section from './Section'; // Assuming Section is in src
-import CatScreen from './CatScreen'; // Assuming CatScreen is in src
+import Section from 'Section';
+import CatScreen from 'CatScreen';
 
 // Define an interface for the route item if available from GTFS data structure
 // For now, using 'any' for flexibility, but should be replaced with actual type
@@ -34,12 +34,13 @@ function RoutesScreen({navigation, routes}: RoutesScreenProps): JSX.Element {
       isDarkMode={isDarkMode}
       data={routes}
       renderDataItem={({item}: {item: RouteItem}) => {
-        // Use route_short_name or route_long_name, or fallback to route_id
         const title = item.route_short_name || item.route_long_name || `Route ID: ${item.route_id}`;
         return (
           <Section
             title={title}
-            onPressHandler={() => {navigation.navigate('Route', {busRouteId: `${item.route_id}`}) }}
+            onPressHandler={() => {
+              navigation.navigate('Route', {busRouteId: `${item.route_id}`});
+            }}
             isDarkMode={isDarkMode}
           />
         );

--- a/src/RoutesScreen.tsx
+++ b/src/RoutesScreen.tsx
@@ -1,26 +1,45 @@
 import React from 'react';
-import {useColorScheme} from 'react-native';
+import {useColorScheme, Text, View} from 'react-native';
 
-import Section from 'Section';
-import CatScreen from 'CatScreen';
+import Section from './Section'; // Assuming Section is in src
+import CatScreen from './CatScreen'; // Assuming CatScreen is in src
 
-function RoutesScreen({navigation}): JSX.Element {
+// Define an interface for the route item if available from GTFS data structure
+// For now, using 'any' for flexibility, but should be replaced with actual type
+interface RouteItem {
+  route_short_name?: string;
+  route_long_name?: string;
+  route_id: string;
+  // Add other relevant route properties here
+}
+
+interface RoutesScreenProps {
+  navigation: any; // Replace with more specific navigation type if available
+  routes: RouteItem[];
+}
+
+function RoutesScreen({navigation, routes}: RoutesScreenProps): JSX.Element {
   const isDarkMode = useColorScheme() === 'dark';
+
+  if (!routes || routes.length === 0) {
+    return (
+      <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+        <Text>No routes data available.</Text>
+      </View>
+    );
+  }
 
   return (
     <CatScreen
       isDarkMode={isDarkMode}
-      data={[
-        {title: 'Route 1', id: 1},
-        {title: 'Route 2', id: 2},
-        {title: 'Route 3', id: 3},
-        {title: 'Route 4', id: 4},
-      ]}
-      renderDataItem={({item}) => {
+      data={routes}
+      renderDataItem={({item}: {item: RouteItem}) => {
+        // Use route_short_name or route_long_name, or fallback to route_id
+        const title = item.route_short_name || item.route_long_name || `Route ID: ${item.route_id}`;
         return (
           <Section
-            title={item.title}
-            onPressHandler={() => {navigation.navigate('Route', {busRouteId: `${ item.id }`}) }}
+            title={title}
+            onPressHandler={() => {navigation.navigate('Route', {busRouteId: `${item.route_id}`}) }}
             isDarkMode={isDarkMode}
           />
         );

--- a/src/RoutesScreen.tsx
+++ b/src/RoutesScreen.tsx
@@ -37,9 +37,9 @@ function RoutesScreen({navigation, routes}: RoutesScreenProps): JSX.Element {
         return (
           <Section
             title={title}
-            onPressHandler={() => {
+            onPressHandler={() =>
               navigation.navigate('Route', {busRouteId: `${item.route_id}`});
-            }}
+            }
             isDarkMode={isDarkMode}
           />
         );

--- a/src/RoutesScreen.tsx
+++ b/src/RoutesScreen.tsx
@@ -4,7 +4,6 @@ import {useColorScheme, Text, View} from 'react-native';
 import Section from 'Section';
 import CatScreen from 'CatScreen';
 
-// Define an interface for the route item if available from GTFS data structure
 // For now, using 'any' for flexibility, but should be replaced with actual type
 interface RouteItem {
   route_short_name?: string;
@@ -14,7 +13,7 @@ interface RouteItem {
 }
 
 interface RoutesScreenProps {
-  navigation: any; // Replace with more specific navigation type if available
+  navigation: any;
   routes: RouteItem[];
 }
 

--- a/src/StopsScreen.tsx
+++ b/src/StopsScreen.tsx
@@ -4,7 +4,6 @@ import {useColorScheme, Text, View} from 'react-native';
 import Section from 'Section';
 import CatScreen from 'CatScreen';
 
-// Define an interface for the stop item if available from GTFS data structure
 // For now, using 'any' for flexibility, but should be replaced with actual type
 interface StopItem {
   stop_name?: string;
@@ -14,7 +13,7 @@ interface StopItem {
 }
 
 interface StopsScreenProps {
-  navigation: any; // Replace with more specific navigation type if available
+  navigation: any;
   stops: StopItem[];
 }
 

--- a/src/StopsScreen.tsx
+++ b/src/StopsScreen.tsx
@@ -1,26 +1,45 @@
 import React from 'react';
-import {useColorScheme} from 'react-native';
+import {useColorScheme, Text, View} from 'react-native';
 
-import Section from 'Section';
-import CatScreen from 'CatScreen';
+import Section from './Section'; // Assuming Section is in src
+import CatScreen from './CatScreen'; // Assuming CatScreen is in src
 
-function StopsScreen({navigation}): JSX.Element {
+// Define an interface for the stop item if available from GTFS data structure
+// For now, using 'any' for flexibility, but should be replaced with actual type
+interface StopItem {
+  stop_name?: string;
+  stop_code?: string;
+  stop_id: string;
+  // Add other relevant stop properties here
+}
+
+interface StopsScreenProps {
+  navigation: any; // Replace with more specific navigation type if available
+  stops: StopItem[];
+}
+
+function StopsScreen({navigation, stops}: StopsScreenProps): JSX.Element {
   const isDarkMode = useColorScheme() === 'dark';
+
+  if (!stops || stops.length === 0) {
+    return (
+      <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+        <Text>No stops data available.</Text>
+      </View>
+    );
+  }
 
   return (
     <CatScreen
       isDarkMode={isDarkMode}
-      data={[
-        {title: 'Stop 1', id: 1},
-        {title: 'Stop 2', id: 2},
-        {title: 'Stop 3', id: 3},
-        {title: 'Stop 4', id: 4},
-      ]}
-      renderDataItem={({item}) => {
+      data={stops}
+      renderDataItem={({item}: {item: StopItem}) => {
+        // Use stop_name or fallback to stop_id
+        const title = item.stop_name || `Stop ID: ${item.stop_id}`;
         return (
           <Section
-            title={item.title}
-            onPressHandler={() => {navigation.navigate('Stop',{stopId: `${ item.id }`}) }}
+            title={title}
+            onPressHandler={() => {navigation.navigate('Stop',{stopId: `${item.stop_id}`}) }}
             isDarkMode={isDarkMode}
           />
         );

--- a/src/StopsScreen.tsx
+++ b/src/StopsScreen.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {useColorScheme, Text, View} from 'react-native';
 
-import Section from './Section'; // Assuming Section is in src
-import CatScreen from './CatScreen'; // Assuming CatScreen is in src
+import Section from 'Section';
+import CatScreen from 'CatScreen';
 
 // Define an interface for the stop item if available from GTFS data structure
 // For now, using 'any' for flexibility, but should be replaced with actual type
@@ -34,12 +34,13 @@ function StopsScreen({navigation, stops}: StopsScreenProps): JSX.Element {
       isDarkMode={isDarkMode}
       data={stops}
       renderDataItem={({item}: {item: StopItem}) => {
-        // Use stop_name or fallback to stop_id
         const title = item.stop_name || `Stop ID: ${item.stop_id}`;
         return (
           <Section
             title={title}
-            onPressHandler={() => {navigation.navigate('Stop',{stopId: `${item.stop_id}`}) }}
+            onPressHandler={() => {
+              navigation.navigate('Stop', {stopId: `${item.stop_id}`});
+            }}
             isDarkMode={isDarkMode}
           />
         );

--- a/src/hooks/useGTFSData.tsx
+++ b/src/hooks/useGTFSData.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from 'react';
+import RNFetchBlob from 'rn-fetch-blob';
+import { unzip } from 'react-native-zip-archive';
+import Papa from 'papaparse';
+
+const GTFS_URL = 'https://oregon-gtfs.trilliumtransit.com/gtfs_data/hoodriver-or-us/hoodriver-or-us.zip';
+
+interface GTFSData {
+  routes?: any[];
+  stops?: any[];
+  trips?: any[];
+}
+
+interface UseGTFSDataOutput {
+  data: GTFSData;
+  loading: boolean;
+  error: Error | null;
+}
+
+const useGTFSData = (): UseGTFSDataOutput => {
+  const [data, setData] = useState<GTFSData>({});
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const dirs = RNFetchBlob.fs.dirs;
+        const zipPath = `${dirs.DocumentDir}/gtfs.zip`;
+        const unzipPath = `${dirs.DocumentDir}/gtfs_unzipped`;
+
+        // Download the zip file
+        const res = await RNFetchBlob.config({
+          path: zipPath,
+        }).fetch('GET', GTFS_URL);
+
+        if (res.info().status !== 200) {
+          throw new Error(`Failed to download GTFS data. Status: ${res.info().status}`);
+        }
+
+        // Unzip the file
+        await RNFetchBlob.fs.mkdir(unzipPath); // Ensure the directory exists
+        const unzippedPath = await unzip(zipPath, unzipPath);
+
+        // Define which files to read
+        const filesToRead = {
+          routes: 'routes.txt',
+          stops: 'stops.txt',
+          trips: 'trips.txt',
+        };
+
+        const parsedData: GTFSData = {};
+
+        for (const key in filesToRead) {
+          const fileName = filesToRead[key as keyof typeof filesToRead];
+          const filePath = `${unzipPath}/${fileName}`;
+
+          // Check if file exists
+          const fileExists = await RNFetchBlob.fs.exists(filePath);
+          if (!fileExists) {
+            console.warn(`File ${fileName} not found in zip.`);
+            parsedData[key as keyof GTFSData] = [];
+            continue;
+          }
+
+          const fileContent = await RNFetchBlob.fs.readFile(filePath, 'utf8');
+
+          // Parse CSV data
+          const parseResult = Papa.parse(fileContent, {
+            header: true,
+            skipEmptyLines: true,
+          });
+
+          if (parseResult.errors.length > 0) {
+            console.warn(`Errors parsing ${fileName}:`, parseResult.errors);
+          }
+          parsedData[key as keyof GTFSData] = parseResult.data;
+        }
+
+        setData(parsedData);
+
+      } catch (e) {
+        if (e instanceof Error) {
+          setError(e);
+        } else {
+          setError(new Error('An unknown error occurred during GTFS data processing.'));
+        }
+        console.error("Error in useGTFSData:", e);
+      } finally {
+        setLoading(false);
+        // Optional: Clean up downloaded and unzipped files
+        // RNFetchBlob.fs.unlink(zipPath).catch(console.error);
+        // RNFetchBlob.fs.unlink(unzipPath).catch(console.error); // This deletes the directory
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return { data, loading, error };
+};
+
+export default useGTFSData;


### PR DESCRIPTION
Integrates a new React hook `useGTFSData` to fetch, unzip, and parse GTFS data from an external URL.

- Downloads GTFS zip file from Trillium transit data.
- Unzips the archive and parses `routes.txt` and `stops.txt` using PapaParse.
- Provides the parsed data, loading, and error states.
- Modifies `App.tsx` to use this hook at the root level.
- Updates `RoutesScreen.tsx` and `StopsScreen.tsx` to consume and display the fetched route and stop information respectively.
- Adds dependencies: `rn-fetch-blob`, `react-native-zip-archive`, `papaparse`.

Note: `TripsScreen.tsx` integration is deferred. iOS native module linking may require `pod install` in the `ios` directory by the user.