### PR TITLE
Add unit tests for GTFS ingestion and screen data loading

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   preset: '@react-native/jest-preset',
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|@react-navigation)/)',
+  ],
 };

--- a/src/__tests__/RouteScreen.test.tsx
+++ b/src/__tests__/RouteScreen.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import RouteScreen from '../RouteScreen';
+import { openDatabase } from '@/db/Database';
+import { NavigationContainer } from '@react-navigation/native';
+
+jest.mock('@/db/Database', () => ({
+  openDatabase: jest.fn(),
+}));
+
+describe('RouteScreen', () => {
+  it('loads and renders stops for a route', async () => {
+    const mockExecute = jest.fn().mockResolvedValue({
+      rows: [
+        { stop_id: 'S1', stop_name: 'Test Stop 1' },
+      ],
+    });
+
+    (openDatabase as jest.Mock).mockResolvedValue({
+      execute: mockExecute,
+    });
+
+    const routeProp = {
+      params: {
+        routeId: 'R1',
+        routeName: 'Test Route 1',
+      },
+    };
+
+    let renderer: ReactTestRenderer.ReactTestRenderer;
+    await ReactTestRenderer.act(async () => {
+      renderer = ReactTestRenderer.create(
+        <NavigationContainer>
+            <RouteScreen navigation={{}} route={routeProp} />
+        </NavigationContainer>
+      );
+    });
+
+    const root = renderer!.root;
+    expect(root.findAllByProps({ title: 'Test Stop 1' }).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/__tests__/RoutesScreen.test.tsx
+++ b/src/__tests__/RoutesScreen.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import RoutesScreen from '../RoutesScreen';
+import { openDatabase } from '@/db/Database';
+import { NavigationContainer } from '@react-navigation/native';
+
+jest.mock('@/db/Database', () => ({
+  openDatabase: jest.fn(),
+}));
+
+describe('RoutesScreen', () => {
+  it('loads and renders routes', async () => {
+    const mockExecute = jest.fn().mockResolvedValue({
+      rows: [
+        { route_id: 'R1', route_short_name: 'Short 1', route_long_name: 'Long 1' },
+      ],
+    });
+
+    (openDatabase as jest.Mock).mockResolvedValue({
+      execute: mockExecute,
+      close: jest.fn(),
+    });
+
+    let renderer: ReactTestRenderer.ReactTestRenderer;
+    await ReactTestRenderer.act(async () => {
+      renderer = ReactTestRenderer.create(
+        <NavigationContainer>
+            <RoutesScreen navigation={{}} />
+        </NavigationContainer>
+      );
+    });
+
+    const root = renderer!.root;
+    expect(root.findAllByProps({ title: 'Long 1' }).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/__tests__/StopScreen.test.tsx
+++ b/src/__tests__/StopScreen.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import StopScreen from '../StopScreen';
+import { openDatabase } from '@/db/Database';
+import { NavigationContainer } from '@react-navigation/native';
+
+jest.mock('@/db/Database', () => ({
+  openDatabase: jest.fn(),
+}));
+
+// Mock getArrivalDate to return a fixed date in the future for tests
+jest.mock('@/gtfs/utils/time', () => ({
+  getArrivalDate: jest.fn((time) => {
+      const d = new Date();
+      d.setHours(23, 59, 59); // future
+      return d;
+  }),
+}));
+
+describe('StopScreen', () => {
+  it('loads and renders routes for a stop', async () => {
+    const mockExecute = jest.fn().mockResolvedValue({
+      rows: [
+        { route_id: 'R1', route_long_name: 'Route 1', arrival_time: '12:00:00' },
+      ],
+    });
+
+    (openDatabase as jest.Mock).mockResolvedValue({
+      execute: mockExecute,
+    });
+
+    const routeProp = {
+      params: {
+        stopId: 'S1',
+        stopName: 'Test Stop 1',
+      },
+    };
+
+    let renderer: ReactTestRenderer.ReactTestRenderer;
+    await ReactTestRenderer.act(async () => {
+      renderer = ReactTestRenderer.create(
+        <NavigationContainer>
+            <StopScreen navigation={{}} route={routeProp} />
+        </NavigationContainer>
+      );
+    });
+
+    const root = renderer!.root;
+    // Check if the route name and arrival time are rendered
+    const sections = root.findAllByProps({ isDarkMode: false }); // Section props
+    const found = sections.some(s => s.props.title && s.props.title.includes('Route 1'));
+    expect(found).toBe(true);
+  });
+});

--- a/src/__tests__/StopsScreen.test.tsx
+++ b/src/__tests__/StopsScreen.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import StopsScreen from '../StopsScreen';
+import { openDatabase } from '@/db/Database';
+import { NavigationContainer } from '@react-navigation/native';
+
+jest.mock('@/db/Database', () => ({
+  openDatabase: jest.fn(),
+}));
+
+describe('StopsScreen', () => {
+  it('loads and renders stops', async () => {
+    const mockExecute = jest.fn().mockResolvedValue({
+      rows: [
+        { stop_id: 'S1', stop_name: 'Test Stop 1', stop_code: '101' },
+        { stop_id: 'S2', stop_name: 'Test Stop 2', stop_code: '102' },
+      ],
+    });
+
+    (openDatabase as jest.Mock).mockResolvedValue({
+      execute: mockExecute,
+    });
+
+    let renderer: ReactTestRenderer.ReactTestRenderer;
+    await ReactTestRenderer.act(async () => {
+      renderer = ReactTestRenderer.create(
+        <NavigationContainer>
+            <StopsScreen navigation={{}} />
+        </NavigationContainer>
+      );
+    });
+
+    const root = renderer!.root;
+    // Check if the stop names are rendered
+    // Use findByProps with title and isDarkMode to be more specific if needed
+    // or just filter them.
+    const sections = root.findAllByProps({ title: 'Test Stop 1' });
+    expect(sections.length).toBeGreaterThanOrEqual(1);
+    expect(root.findAllByProps({ title: 'Test Stop 2' }).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/gtfs/__tests__/ingestCore.test.ts
+++ b/src/gtfs/__tests__/ingestCore.test.ts
@@ -1,0 +1,73 @@
+import { ingestFromCsvFiles } from '../ingestCore';
+import { Database } from '@/db/Database';
+import Papa from 'papaparse';
+
+jest.mock('papaparse');
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+  },
+}));
+
+describe('ingestCore', () => {
+  let mockDb: jest.Mocked<Database>;
+
+  beforeEach(() => {
+    mockDb = {
+      execute: jest.fn(),
+      executeBatch: jest.fn().mockResolvedValue([]),
+      withTransaction: jest.fn(),
+      close: jest.fn(),
+    } as any;
+
+    (Papa.parse as jest.Mock).mockImplementation((csv, options) => {
+      if (options.complete) {
+        // Return some dummy data based on what's being parsed
+        let data: any[] = [];
+        if (csv.includes('route_id')) {
+          data = [{ route_id: 'R1', route_long_name: 'Route 1' }];
+        } else if (csv.includes('stop_id')) {
+          data = [{ stop_id: 'S1', stop_name: 'Stop 1' }];
+        }
+        options.complete({ data });
+      }
+    });
+  });
+
+  it('should ingest routes and stops from CSV files', async () => {
+    const files = {
+      'routes.txt': 'route_id,route_long_name\nR1,Route 1',
+      'stops.txt': 'stop_id,stop_name\nS1,Stop 1',
+    };
+
+    await ingestFromCsvFiles(mockDb, 'test-feed', files);
+
+    expect(mockDb.executeBatch).toHaveBeenCalled();
+    // Check if routes were inserted
+    const routeCall = mockDb.executeBatch.mock.calls.find(call =>
+      call[0][0].sql.includes('INSERT INTO routes')
+    );
+    expect(routeCall).toBeDefined();
+    expect(routeCall![0][0].params).toContain('R1');
+
+    // Check if stops were inserted
+    const stopCall = mockDb.executeBatch.mock.calls.find(call =>
+      call[0][0].sql.includes('INSERT INTO stops')
+    );
+    expect(stopCall).toBeDefined();
+    expect(stopCall![0][0].params).toContain('S1');
+  });
+
+  it('should skip missing optional files', async () => {
+    const files = {
+      'routes.txt': 'route_id,route_long_name\nR1,Route 1',
+    };
+
+    await ingestFromCsvFiles(mockDb, 'test-feed', files);
+
+    const stopCall = mockDb.executeBatch.mock.calls.find(call =>
+        call[0][0].sql.includes('INSERT INTO stops')
+    );
+    expect(stopCall).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implemented unit tests for the GTFS feed CSV extract and the load functions in the Stops, Stop, Routes, and Route screens. Used react-test-renderer and mocked the database layer to verify that data is correctly fetched and rendered. Updated Jest configuration to support transformation of React Navigation modules.

---
*PR created automatically by Jules for task [11385583005216350482](https://jules.google.com/task/11385583005216350482) started by @bloihl*