### PR TITLE
Fix act warnings and database console errors in screen tests

### DIFF
--- a/src/__tests__/RouteScreen.test.tsx
+++ b/src/__tests__/RouteScreen.test.tsx
@@ -19,10 +19,18 @@ jest.mock('@/gtfs/utils/time', () => ({
 
 describe('RouteScreen', () => {
   it('loads and renders stops for a route with next arrival time', async () => {
-    const mockExecute = jest.fn().mockResolvedValue({
-      rows: [
-        { stop_id: 'S1', stop_name: 'Test Stop 1', arrival_time: '12:00:00' },
-      ],
+    jest.useFakeTimers();
+    const mockExecute = jest.fn().mockImplementation((sql: string) => {
+      if (sql.includes('feed_meta')) {
+        return Promise.resolve({
+          rows: [{ freshnessDate: '2023-01-01' }],
+        });
+      }
+      return Promise.resolve({
+        rows: [
+          { stop_id: 'S1', stop_name: 'Test Stop 1', arrival_time: '12:00:00' },
+        ],
+      });
     });
 
     (openDatabase as jest.Mock).mockResolvedValue({
@@ -43,6 +51,7 @@ describe('RouteScreen', () => {
             <RouteScreen navigation={{}} route={routeProp} />
         </NavigationContainer>
       );
+      jest.runAllTimers();
     });
 
     const root = renderer!.root;

--- a/src/__tests__/RoutesScreen.test.tsx
+++ b/src/__tests__/RoutesScreen.test.tsx
@@ -10,10 +10,18 @@ jest.mock('@/db/Database', () => ({
 
 describe('RoutesScreen', () => {
   it('loads and renders routes', async () => {
-    const mockExecute = jest.fn().mockResolvedValue({
-      rows: [
-        { route_id: 'R1', route_short_name: 'Short 1', route_long_name: 'Long 1' },
-      ],
+    jest.useFakeTimers();
+    const mockExecute = jest.fn().mockImplementation((sql: string) => {
+      if (sql.includes('feed_meta')) {
+        return Promise.resolve({
+          rows: [{ freshnessDate: '2023-01-01' }],
+        });
+      }
+      return Promise.resolve({
+        rows: [
+          { route_id: 'R1', route_short_name: 'Short 1', route_long_name: 'Long 1' },
+        ],
+      });
     });
 
     (openDatabase as jest.Mock).mockResolvedValue({
@@ -28,6 +36,7 @@ describe('RoutesScreen', () => {
             <RoutesScreen navigation={{}} />
         </NavigationContainer>
       );
+      jest.runAllTimers();
     });
 
     const root = renderer!.root;

--- a/src/__tests__/StopScreen.test.tsx
+++ b/src/__tests__/StopScreen.test.tsx
@@ -19,10 +19,18 @@ jest.mock('@/gtfs/utils/time', () => ({
 
 describe('StopScreen', () => {
   it('loads and renders routes for a stop', async () => {
-    const mockExecute = jest.fn().mockResolvedValue({
-      rows: [
-        { route_id: 'R1', route_long_name: 'Route 1', arrival_time: '12:00:00' },
-      ],
+    jest.useFakeTimers();
+    const mockExecute = jest.fn().mockImplementation((sql: string) => {
+      if (sql.includes('feed_meta')) {
+        return Promise.resolve({
+          rows: [{ freshnessDate: '2023-01-01' }],
+        });
+      }
+      return Promise.resolve({
+        rows: [
+          { route_id: 'R1', route_long_name: 'Route 1', arrival_time: '12:00:00' },
+        ],
+      });
     });
 
     (openDatabase as jest.Mock).mockResolvedValue({
@@ -43,6 +51,7 @@ describe('StopScreen', () => {
             <StopScreen navigation={{}} route={routeProp} />
         </NavigationContainer>
       );
+      jest.runAllTimers();
     });
 
     const root = renderer!.root;

--- a/src/__tests__/StopsScreen.test.tsx
+++ b/src/__tests__/StopsScreen.test.tsx
@@ -10,11 +10,19 @@ jest.mock('@/db/Database', () => ({
 
 describe('StopsScreen', () => {
   it('loads and renders stops', async () => {
-    const mockExecute = jest.fn().mockResolvedValue({
-      rows: [
-        { stop_id: 'S1', stop_name: 'Test Stop 1', stop_code: '101' },
-        { stop_id: 'S2', stop_name: 'Test Stop 2', stop_code: '102' },
-      ],
+    jest.useFakeTimers();
+    const mockExecute = jest.fn().mockImplementation((sql: string) => {
+      if (sql.includes('feed_meta')) {
+        return Promise.resolve({
+          rows: [{ freshnessDate: '2023-01-01' }],
+        });
+      }
+      return Promise.resolve({
+        rows: [
+          { stop_id: 'S1', stop_name: 'Test Stop 1', stop_code: '101' },
+          { stop_id: 'S2', stop_name: 'Test Stop 2', stop_code: '102' },
+        ],
+      });
     });
 
     (openDatabase as jest.Mock).mockResolvedValue({
@@ -28,6 +36,7 @@ describe('StopsScreen', () => {
             <StopsScreen navigation={{}} />
         </NavigationContainer>
       );
+      jest.runAllTimers();
     });
 
     const root = renderer!.root;


### PR DESCRIPTION
I fixed the `act()` warnings and the "Cannot log after tests are done" errors in the screen tests. 

The issue was caused by `VirtualizedList` (used via `FlatList`) scheduling internal timeouts that fired after the `act()` block had finished. By using `jest.useFakeTimers()` and calling `jest.runAllTimers()` within the `act()` block, I ensured all these updates are processed during the test.

Additionally, I improved the `openDatabase.execute` mock in the tests to handle the `feed_meta` query used in `CatScreen`. This avoids the console error regarding unexpected row counts in the `feed_meta` table and ensures the component's state is correctly initialized during tests.

---
*PR created automatically by Jules for task [3894565326969135895](https://jules.google.com/task/3894565326969135895) started by @bloihl*