### PR TITLE
Fix Jest Dynamic Import Warning and Test Timeouts

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -6,6 +6,10 @@ import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 import App from '../App';
 
+jest.mock('@/db/migrations', () => ({
+  runMigrations: jest.fn().mockResolvedValue(undefined),
+}));
+
 test('renders correctly', async () => {
   await ReactTestRenderer.act(() => {
     ReactTestRenderer.create(<App />);

--- a/src/__tests__/RouteScreen.test.tsx
+++ b/src/__tests__/RouteScreen.test.tsx
@@ -51,7 +51,7 @@ describe('RouteScreen', () => {
             <RouteScreen navigation={{}} route={routeProp} />
         </NavigationContainer>
       );
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
     });
 
     const root = renderer!.root;

--- a/src/__tests__/StopScreen.test.tsx
+++ b/src/__tests__/StopScreen.test.tsx
@@ -51,7 +51,7 @@ describe('StopScreen', () => {
             <StopScreen navigation={{}} route={routeProp} />
         </NavigationContainer>
       );
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
     });
 
     const root = renderer!.root;

--- a/src/__tests__/StopsScreen.test.tsx
+++ b/src/__tests__/StopsScreen.test.tsx
@@ -36,7 +36,7 @@ describe('StopsScreen', () => {
             <StopsScreen navigation={{}} />
         </NavigationContainer>
       );
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
     });
 
     const root = renderer!.root;


### PR DESCRIPTION
This PR fixes two main issues in the test suite:
1. **Dynamic Import Warning**: The `App` component triggers database migrations on mount. These migrations use dynamic imports to load platform-specific database adapters, which causes a warning/error in Jest because it doesn't support dynamic imports without the `--experimental-vm-modules` flag. By mocking `runMigrations` in the `App.test.tsx`, we avoid this issue for the basic render smoke test.
2. **Test Timeouts**: Several screen tests were timing out because they used `jest.runAllTimers()`, which can hang if there are recurring timers (e.g., from navigation or other libraries). Switching to `jest.runOnlyPendingTimers()` ensures that asynchronous effects are flushed without waiting for an infinite or long-running timer queue.

---
*PR created automatically by Jules for task [16382623775661976371](https://jules.google.com/task/16382623775661976371) started by @bloihl*